### PR TITLE
Show "did you mean" prompt when rawScore == weight

### DIFF
--- a/site/static/js/app.js
+++ b/site/static/js/app.js
@@ -95,7 +95,7 @@ function AssessmentItemVm(task, weight, id) {
 
     // Prompt
     self.showPrompt = ko.pureComputed(function() {
-        return (/^\d+$/.test(self.rawScore()) && Number(self.rawScore()) > 0 && Number(self.rawScore()) < Number(self.weight()));
+        return (/^\d+$/.test(self.rawScore()) && Number(self.rawScore()) > 0 && Number(self.rawScore()) <= Number(self.weight()));
     });
 
     self.promptPercentText = ko.pureComputed(function() {


### PR DESCRIPTION
A user who got 100% on an item might enter e.g. "20" instead of "20/20".