### PR TITLE
Use response.data instead of response.response when building API response

### DIFF
--- a/api/uqfinalapi/helpers.py
+++ b/api/uqfinalapi/helpers.py
@@ -64,7 +64,7 @@ def api_response(f):
             }
             response.status_code = 500
 
-        response.response = json.dumps(result)
+        response.data = json.dumps(result)
         return response
 
     return inner


### PR DESCRIPTION
This fixes a warning from Flask (and the underlying issue) whereby the HTTP server will send the response char by char. 

> Warning: response iterable was set to a string.  This appears to work but means that the server will send the data to the client char, by char.  This is almost never intended behavior, use response.data to assign strings to the response object.